### PR TITLE
mmap memory leakage fix

### DIFF
--- a/camera.c
+++ b/camera.c
@@ -74,6 +74,8 @@ struct getbuf_return get_buffer(int fd) {
 	return_struct.buffer = mmap (NULL, buf.length, PROT_READ | PROT_WRITE,\
 		MAP_SHARED, fd, buf.m.offset);
 
+	return_struct.length = buf.length;
+
 	// Consoom frame and get excited for next frame
 	if (-1 == xioctl(fd, VIDIOC_STREAMON, &buf.type)) {
 		perror("Starting capture");

--- a/camera.h
+++ b/camera.h
@@ -4,6 +4,7 @@
 struct getbuf_return {
 	uint8_t	*buffer;
 	int 	code;
+	int 	length;
 };
 
 extern int camera_init(char* device, int PXWIDTH, int PXHEIGHT);

--- a/main.c
+++ b/main.c
@@ -147,6 +147,9 @@ int main(int argc, char **argv) {
 		brightness = getbrightness(buffer)*offset;
 		setbacklight(brightness, fade);
 
+		// unmap v4l2 buffer from system memory
+		munmap(mybuffer.buffer, mybuffer.length);
+		
 		sleep(time);
 
 		// get offset as a multiplier


### PR DESCRIPTION
This fixes the mmap memory leakage.
With every recorded frame, the picture is mapped into memory with mmap, but never unmapped again.
Over time the memory usage of this programm builds up (around 200KB every few seconds on my system).
The system frees up mapped memory only at the end of execution, not meanwhile.

mmap() without munmap() can be tricky, see https://stackoverflow.com/a/62286747.