### PR TITLE
Malloc Memory Leak and Camera Closing Fix

### DIFF
--- a/camera.c
+++ b/camera.c
@@ -2,6 +2,7 @@
 #include <sys/mman.h>			// mmap() function
 #include <sys/ioctl.h>			// interface with V4L2 
 #include <fcntl.h>				// open() function
+#include <unistd.h>				// close() function
 #include <errno.h>				// Error handling
 #include <stdio.h>				//
 #include <stdint.h>				// uint8_t for the buffer
@@ -57,6 +58,20 @@ int camera_init(char* device, int PXWIDTH, int PXHEIGHT) {
 
 	return fd;
 }
+
+
+int camera_close(int fd) {
+	// close camera device
+	int ret = close(fd);
+	if (ret == -1) 
+	{
+		perror("Error closing camera");
+		return -1;
+	}
+
+	return 0;
+}
+
 
 struct getbuf_return get_buffer(int fd) {
 	struct getbuf_return return_struct;

--- a/camera.h
+++ b/camera.h
@@ -8,6 +8,7 @@ struct getbuf_return {
 };
 
 extern int camera_init(char* device, int PXWIDTH, int PXHEIGHT);
+extern int camera_close(int fd);
 
 extern struct getbuf_return get_buffer(int fd);
 

--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@ char *device;
 
 float getbacklight() {
 	FILE *pipe = popen("xbacklight -get", "r");
-	char *temp = malloc(16);
+	char temp[16];
 	fscanf(pipe, "%s", temp);
 	float retval = atof(temp);
 	pclose(pipe);
@@ -161,6 +161,9 @@ int main(int argc, char **argv) {
 	}	
 	while (oneshot_flag != 1);
 
-	// Never gets used lmao
-	return 0;
+	// close camera connection
+	int ret = camera_close(fd);
+
+	// returns 0 if camera_close was successful, else -1
+	return ret;
 }


### PR DESCRIPTION
**Malloc Memory Leak**

In function getbacklight() you allocate 16 bytes on the heap with malloc, but you could just use a temporary array, like you did in getbrightness(). Especially when the array has fixed size on compile time. Another advantage is that you can't forget deallocating the memory by not calling free(temp) and therefore causing a memory leak, like you did ;)

**Camera Closing**

The camera device is accessed using open(), but close() (from unistd.h) is never called. So you fully depend on the system itself for closing the connection at the end of execution.
I added a camera_close() function, which is called after the main loop. So the device is at least closed correctly in oneshot mode.

